### PR TITLE
Initial Dockerfile

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -23,13 +23,23 @@ Otherwise, build without NVIDIA Docker:
 ```
 
 To spin up a container from an image:
+
+If you built with NVIDIA, use
 ```
-./run.bash icra2023_tutorial
+./run.bash icra2023_tutorial_nvidia
+```
+Otherwise, use
+```
+./run.bash icra2023_tutorial_no_nvidia --no-nvidia
 ```
 
 To join a running container from another terminal:
 ```
-./join.bash icra2023_tutorial
+./join.bash icra2023_tutorial_nvidia
+```
+Or
+```
+./join.bash icra2023_tutorial_no_nvidia
 ```
 
 ## Test the image

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,53 @@
+Docker environments to run the tutorials in this repository.
+
+## Example usage
+
+To build an image:
+```
+./build.bash icra2023_tutorial_nvidia
+```
+
+To spin up a container from an image:
+```
+./run.bash icra2023_tutorial_nvidia
+```
+
+To join a running container from another terminal:
+```
+./join.bash icra2023_tutorial_nvidia
+```
+
+## Test the image
+
+After building and running the image, try the following commands inside the container.
+
+ROS 2:
+```
+$ . /opt/ros/humble/setup.bash 
+$ ros2 topic list
+/parameter_events
+/rosout
+```
+
+Gazebo:
+```
+gz sim
+```
+The Gazebo GUI should show up.
+
+## Docker cheat sheet
+
+To list all images built:
+```
+docker images
+```
+
+To remove an image:
+```
+docker image rm <IMAGE ID>
+```
+
+To untag an image (if this is the only tag for the IMAGE ID, the image will be removed):
+```
+docker image rmi <REPOSITORY:TAG>
+```

--- a/docker/README.md
+++ b/docker/README.md
@@ -83,3 +83,7 @@ xauth: (argv):1:  unable to read any entries from file "(stdin)"
 chmod: changing permissions of '/tmp/.docker.xauth': Operation not permitted
 ```
 
+If they don't work, you can also try the following on the host machine:
+```
+xhost + local:
+```

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,5 +1,10 @@
 Docker environments to run the tutorials in this repository.
 
+## Prerequisites
+
+Install Docker and NVIDIA Docker 2 (if your machine has an NVIDIA GPU) following
+instructions [here](https://github.com/osrf/subt/wiki/Docker%20Install).
+
 ## Example usage
 
 To build an image:
@@ -19,7 +24,8 @@ To join a running container from another terminal:
 
 ## Test the image
 
-After building and running the image, try the following commands inside the container.
+After building and running the image, try the following commands inside the
+container.
 
 ROS 2:
 ```
@@ -47,7 +53,8 @@ To remove an image:
 docker image rm <IMAGE ID>
 ```
 
-To untag an image (if this is the only tag for the IMAGE ID, the image will be removed):
+To untag an image (if this is the only tag for the IMAGE ID, the image will be
+removed):
 ```
 docker image rmi <REPOSITORY:TAG>
 ```

--- a/docker/README.md
+++ b/docker/README.md
@@ -23,23 +23,13 @@ Otherwise, build without NVIDIA Docker:
 ```
 
 To spin up a container from an image:
-
-If you built with NVIDIA, use
 ```
-./run.bash icra2023_tutorial_nvidia
-```
-Otherwise, use
-```
-./run.bash icra2023_tutorial_no_nvidia --no-nvidia
+./run.bash icra2023_tutorial
 ```
 
 To join a running container from another terminal:
 ```
-./join.bash icra2023_tutorial_nvidia
-```
-Or
-```
-./join.bash icra2023_tutorial_no_nvidia
+./join.bash icra2023_tutorial
 ```
 
 ## Test the image

--- a/docker/README.md
+++ b/docker/README.md
@@ -24,12 +24,12 @@ Otherwise, build without NVIDIA Docker:
 
 To spin up a container from an image:
 ```
-./run.bash icra2023_tutorial_nvidia
+./run.bash icra2023_tutorial
 ```
 
 To join a running container from another terminal:
 ```
-./join.bash icra2023_tutorial_nvidia
+./join.bash icra2023_tutorial
 ```
 
 ## Test the image

--- a/docker/README.md
+++ b/docker/README.md
@@ -2,14 +2,24 @@ Docker environments to run the tutorials in this repository.
 
 ## Prerequisites
 
-Install Docker and NVIDIA Docker 2 (if your machine has an NVIDIA GPU) following
+If your machine has an NVIDIA GPU, install Docker and NVIDIA Docker 2 following
 instructions [here](https://github.com/osrf/subt/wiki/Docker%20Install).
+
+If you don't have an NVIDIA GPU, Gazebo GUI will use software rendering via
+Mesa llvmpipe (you can check that in ~/.gz/rendering/ogre2.log after starting
+the Gazebo GUI).
 
 ## Example usage
 
 To build an image:
+
+If you have an NVIDIA graphics card, build using the NVIDIA Docker base image:
 ```
-./build.bash icra2023_tutorial_nvidia
+./build.bash icra2023_tutorial
+```
+Otherwise, build without NVIDIA Docker:
+```
+./build.bash icra2023_tutorial --no-nvidia
 ```
 
 To spin up a container from an image:
@@ -33,7 +43,9 @@ $ . /opt/ros/humble/setup.bash
 $ ros2 topic list
 /parameter_events
 /rosout
+$ rviz2
 ```
+The RViz GUI should show up.
 
 Gazebo:
 ```
@@ -58,3 +70,16 @@ removed):
 ```
 docker image rmi <REPOSITORY:TAG>
 ```
+
+## Troubleshoot
+
+# xauth permission denied
+
+If you get the following printout after executing `run.bash`, but the GUIs still
+work for you, you can ignore the messages.
+```
+xauth:  /tmp/.docker.xauth not writable, changes will be ignored
+xauth: (argv):1:  unable to read any entries from file "(stdin)"
+chmod: changing permissions of '/tmp/.docker.xauth': Operation not permitted
+```
+

--- a/docker/build.bash
+++ b/docker/build.bash
@@ -18,15 +18,47 @@
 #
 
 # Builds a Docker image.
+# Example usage:
+# If you have an NVIDIA graphics card
+#   $ ./build.bash icra2023_tutorial
+# Otherwise
+#   $ ./build.bash icra2023_tutorial --no-nvidia
 
+# No arg
 if [ $# -eq 0 ]
 then
     echo "Usage: $0 directory-name"
     exit 1
 fi
 
-# get path to current directory
+# Get path to current directory
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# Default base image, defined in nvidia_opengl_ubuntu22/Dockerfile
+base="nvidia_opengl_ubuntu22:latest"
+image_suffix="_nvidia"
+
+# Parse and remove args
+PARAMS=""
+while (( "$#" )); do
+  case "$1" in
+    --no-nvidia)
+      base="ubuntu:jammy"
+      image_suffix="_no_nvidia"
+      shift
+      ;;
+    -*|--*=) # unsupported flags
+      echo "Error: Unsupported flag $1" >&2
+      exit 1
+      ;;
+    *) # preserve positional arguments
+      PARAMS="$PARAMS $1"
+      shift
+      ;;
+  esac
+done
+# set positional arguments in their proper place
+eval set -- "$PARAMS"
 
 if [ ! -d $DIR/$1 ]
 then
@@ -40,7 +72,10 @@ image_name=$(basename $1)
 # Tag as latest so don't have a dozen uniquely timestamped images hanging around
 image_plus_tag=$image_name:latest
 
-docker build --rm -t $image_plus_tag --build-arg user_id=$user_id $DIR/$image_name
-#docker tag $image_plus_tag $image_name:latest
+echo "Building $image_name with base image $base"
+docker build --rm -t $image_plus_tag --build-arg base=$base --build-arg user_id=$user_id $DIR/$image_name
+echo "Built $image_plus_tag"
 
-echo "Built $image_plus_tag and tagged as $image_name:latest"
+# Extra tag in case you have both the NVIDIA and no-NVIDIA images
+docker tag $image_plus_tag $image_name$image_suffix:latest
+echo "Tagged as $image_name$image_suffix:latest"

--- a/docker/build.bash
+++ b/docker/build.bash
@@ -70,11 +70,12 @@ user_id=$(id -u)
 image_name=$(basename $1)
 #image_plus_tag=$image_name:$(date +%Y_%b_%d_%H%M)
 # Tag as latest so don't have a dozen uniquely timestamped images hanging around
-image_plus_tag=$image_name$image_suffix:latest
+image_plus_tag=$image_name:latest
 
 echo "Building $image_name with base image $base"
 docker build --rm -t $image_plus_tag --build-arg base=$base --build-arg user_id=$user_id $DIR/$image_name
 echo "Built $image_plus_tag"
 
-#docker tag $image_plus_tag $image_name$image_suffix:latest
-#echo "Tagged as $image_name$image_suffix:latest"
+# Extra tag in case you have both the NVIDIA and no-NVIDIA images
+docker tag $image_plus_tag $image_name$image_suffix:latest
+echo "Tagged as $image_name$image_suffix:latest"

--- a/docker/build.bash
+++ b/docker/build.bash
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+#
+# Copyright (C) 2023 Open Source Robotics Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+
+# Builds a Docker image.
+
+if [ $# -eq 0 ]
+then
+    echo "Usage: $0 directory-name"
+    exit 1
+fi
+
+# get path to current directory
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+if [ ! -d $DIR/$1 ]
+then
+  echo "image-name must be a directory in the same folder as this script"
+  exit 2
+fi
+
+user_id=$(id -u)
+image_name=$(basename $1)
+#image_plus_tag=$image_name:$(date +%Y_%b_%d_%H%M)
+# Tag as latest so don't have a dozen uniquely timestamped images hanging around
+image_plus_tag=$image_name:latest
+
+docker build --rm -t $image_plus_tag --build-arg user_id=$user_id $DIR/$image_name
+#docker tag $image_plus_tag $image_name:latest
+
+echo "Built $image_plus_tag and tagged as $image_name:latest"

--- a/docker/build.bash
+++ b/docker/build.bash
@@ -70,12 +70,11 @@ user_id=$(id -u)
 image_name=$(basename $1)
 #image_plus_tag=$image_name:$(date +%Y_%b_%d_%H%M)
 # Tag as latest so don't have a dozen uniquely timestamped images hanging around
-image_plus_tag=$image_name:latest
+image_plus_tag=$image_name$image_suffix:latest
 
 echo "Building $image_name with base image $base"
 docker build --rm -t $image_plus_tag --build-arg base=$base --build-arg user_id=$user_id $DIR/$image_name
 echo "Built $image_plus_tag"
 
-# Extra tag in case you have both the NVIDIA and no-NVIDIA images
-docker tag $image_plus_tag $image_name$image_suffix:latest
-echo "Tagged as $image_name$image_suffix:latest"
+#docker tag $image_plus_tag $image_name$image_suffix:latest
+#echo "Tagged as $image_name$image_suffix:latest"

--- a/docker/icra2023_tutorial/Dockerfile
+++ b/docker/icra2023_tutorial/Dockerfile
@@ -25,8 +25,11 @@
 # https://hub.docker.com/r/nvidia/opengl
 #FROM nvidia/opengl:1.0-glvnd-devel-ubuntu22.04
 # Use homebrewed version until above exists officially
-# From ../nvidia_opengl_ubuntu22/Dockerfile
-FROM nvidia_opengl_ubuntu22:latest
+# Image is in ../nvidia_opengl_ubuntu22/Dockerfile
+#FROM nvidia_opengl_ubuntu22:latest
+# Base image. NVIDIA or no-NVIDIA.
+ARG base
+FROM ${base}
 
 # This avoids keyboard interaction when asked for geographic area
 ARG DEBIAN_FRONTEND=noninteractive

--- a/docker/icra2023_tutorial_nvidia/Dockerfile
+++ b/docker/icra2023_tutorial_nvidia/Dockerfile
@@ -1,0 +1,102 @@
+#
+# Copyright (C) 2023 Open Source Robotics Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# ROS 2 Humble binary install
+# http://docs.ros.org/en/humble/Installation/Ubuntu-Install-Debians.html
+
+# Gazebo Garden binary install
+# https://gazebosim.org/docs/garden/install_ubuntu
+
+# Doesn't exist for Ubuntu 2022 yet at time of writing
+# Ubuntu with nvidia-docker2 beta opengl support
+# https://hub.docker.com/r/nvidia/opengl
+#FROM nvidia/opengl:1.0-glvnd-devel-ubuntu22.04
+# Use homebrewed version until above exists officially
+# From ../nvidia_opengl_ubuntu22/Dockerfile
+FROM nvidia_opengl_ubuntu22:latest
+
+# This avoids keyboard interaction when asked for geographic area
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+ && apt-get install -y \
+        build-essential \
+        cmake \
+        cppcheck \
+        curl \
+        doxygen \
+        gdb \
+        git \
+        gnupg2 \
+        libbluetooth-dev \
+        libcwiid-dev \
+        libgoogle-glog-dev \
+        libspnav-dev \
+        libusb-dev \
+        locales \
+        lsb-release \
+        mercurial \
+        python3-dbg \
+        python3-empy \
+        python3-numpy \
+        python3-pip \
+        python3-psutil \
+        python3-venv \
+        software-properties-common \
+        sudo \
+        tzdata \
+        vim \
+        wget \
+        curl \
+ && apt-get clean
+
+# Set Locale for ROS 2
+RUN locale-gen en_US en_US.UTF-8 && \
+  update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8 && \
+  export LANG=en_US.UTF-8
+
+# Add ROS 2 apt repository
+# Set up keys
+RUN curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | apt-key add -
+# Set up sources.list
+RUN sh -c 'echo "deb [arch=amd64,arm64] http://packages.ros.org/ros2/ubuntu `lsb_release -cs` main" > /etc/apt/sources.list.d/ros2-latest.list'
+
+RUN export DEBIAN_FRONTEND=noninteractive
+
+# Install ROS 2, Gazebo, and build tools
+# https://colcon.readthedocs.io/en/released/user/installation.html
+RUN /bin/sh -c 'wget https://packages.osrfoundation.org/gazebo.gpg -O /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg' \
+ && /bin/sh -c 'echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg] http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null' \
+ && apt-get update \
+ && apt-get install -y \
+    python3-vcstool \
+    python3-colcon-common-extensions \
+    ros-humble-desktop \
+    gz-garden \
+ && apt-get clean
+
+# Add a user with the same user_id as the user outside the container
+# Requires a docker build argument `user_id`
+ARG user_id
+ENV USERNAME developer
+RUN useradd -U --uid ${user_id} -ms /bin/bash $USERNAME \
+ && echo "$USERNAME:$USERNAME" | chpasswd \
+ && adduser $USERNAME sudo \
+ && echo "$USERNAME ALL=NOPASSWD: ALL" >> /etc/sudoers.d/$USERNAME
+# Commands below run as the developer user
+USER $USERNAME
+# When running a container start in the developer's home folder
+WORKDIR /home/$USERNAME

--- a/docker/join.bash
+++ b/docker/join.bash
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+#
+# Copyright (C) 2023 Open Source Robotics Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+
+IMG=$(basename $1)
+# Use quotes if image name contains symbols like a forward slash /, but then
+# cannot use `basename`.
+#IMG="$1"
+
+xhost +
+containerid=$(docker ps -aqf "ancestor=${IMG}")
+docker exec --privileged -e DISPLAY=${DISPLAY} -e LINES=`tput lines` -it ${containerid} bash
+xhost -

--- a/docker/nvidia_opengl_ubuntu22/Dockerfile
+++ b/docker/nvidia_opengl_ubuntu22/Dockerfile
@@ -1,0 +1,63 @@
+#
+# Copyright (C) 2023 Open Source Robotics Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Since nvidia/opengl:*-glvnd-devel-ubuntu22.04 is not available yet, this
+# builds an equivalent, to run X server in an Ubuntu 20.04 Docker image.
+# https://hub.docker.com/r/nvidia/opengl
+
+FROM ubuntu:jammy
+
+#####
+# Following lines are copied from
+# https://gitlab.com/nvidia/container-images/opengl/-/blob/ubuntu18.04/base/Dockerfile
+# and removed :i386 packages (not found)
+RUN dpkg --add-architecture i386 \
+ && apt-get update \
+ && apt-get install -y --no-install-recommends \
+        libxau6 libxau6:i386 \
+        libxdmcp6 libxdmcp6:i386 \
+        libxcb1 libxcb1:i386 \
+        libxext6 libxext6:i386 \
+        libx11-6 libx11-6:i386 && \
+    rm -rf /var/lib/apt/lists/*
+
+# nvidia-container-runtime
+ENV NVIDIA_VISIBLE_DEVICES \
+        ${NVIDIA_VISIBLE_DEVICES:-all}
+ENV NVIDIA_DRIVER_CAPABILITIES \
+        ${NVIDIA_DRIVER_CAPABILITIES:+$NVIDIA_DRIVER_CAPABILITIES,}graphics,compat32,utility
+
+RUN echo "/usr/local/nvidia/lib" >> /etc/ld.so.conf.d/nvidia.conf && \
+    echo "/usr/local/nvidia/lib64" >> /etc/ld.so.conf.d/nvidia.conf
+
+# https://gitlab.com/nvidia/container-images/opengl/-/blob/ubuntu20.04/NGC-DL-CONTAINER-LICENSE
+COPY NGC-DL-CONTAINER-LICENSE /
+
+# Required for non-glvnd setups.
+ENV LD_LIBRARY_PATH /usr/lib/x86_64-linux-gnu:/usr/lib/i386-linux-gnu${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}:/usr/local/nvidia/lib:/usr/local/nvidia/lib64
+
+#####
+# Copied from
+# https://gitlab.com/nvidia/container-images/opengl/blob/ubuntu20.04/glvnd/devel/Dockerfile
+# and removed :i386 packages (not found)
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+        pkg-config \
+        libglvnd-dev libglvnd-dev:i386 \
+        libgl1-mesa-dev libgl1-mesa-dev:i386 \
+        libegl1-mesa-dev libegl1-mesa-dev:i386 \
+        libgles2-mesa-dev libgles2-mesa-dev:i386 && \
+    rm -rf /var/lib/apt/lists/*

--- a/docker/nvidia_opengl_ubuntu22/NGC-DL-CONTAINER-LICENSE
+++ b/docker/nvidia_opengl_ubuntu22/NGC-DL-CONTAINER-LICENSE
@@ -1,0 +1,230 @@
+NVIDIA DEEP LEARNING CONTAINER LICENSE
+
+This license is a legal agreement between you and NVIDIA Corporation ("NVIDIA") and governs the use
+of the NVIDIA container and all its contents (“CONTAINER”).
+
+This license can be accepted only by an adult of legal age of majority in the country in which the
+CONTAINER is used. If you are under the legal age of majority, you must ask your parent or legal
+guardian to consent to this license. If you are entering this license on behalf of a company or
+other legal entity, you represent that you have legal authority and “you” will mean the entity you
+represent.
+
+By using the CONTAINER, you affirm that you have reached the legal age of majority, you accept the
+terms of this license, and you take legal and financial responsibility for the actions of your
+permitted users.
+
+You agree to use the CONTAINER only for purposes that are permitted by (a) this license, and (b) any
+applicable law, regulation or generally accepted practices or guidelines in the relevant
+jurisdictions.
+
+1. LICENSE. Subject to the terms of this license, NVIDIA hereby grants you a non-exclusive,
+non-transferable license, without the right to sublicense (except as expressly provided in this
+license) to:
+
+a. Install and use copies of the CONTAINER, and modify and create derivative works of samples or
+example source code delivered in the CONTAINER (if applicable), to develop and test services and
+applications,
+
+b. Deploy the CONTAINER on infrastructure you own or lease to offer a service to third parties,
+without distributing the CONTAINER or exposing the NVIDIA APIs in the CONTAINER directly to such
+service users, and
+
+c. Develop and extend the CONTAINER to create a Compatible (as defined below) derived CONTAINER that
+includes the entire CONTAINER plus other software with primary functionality, to develop and compile
+applications, and distribute such derived CONTAINER to run applications, subject to the distribution
+requirements indicated in this license. As used in this section, “Compatible” means that extensions
+to the CONTAINER must not adversely affect the functionality of the other components in the
+CONTAINER.
+
+2. DISTRIBUTION REQUIREMENTS. For purposes of this Section 2, the term “distribution” also means the
+deployment of CONTAINERS in a service or an application for third parties to access over the
+internet. These are the distribution requirements for you to exercise the grants above:
+
+a. A service or an application must have material additional functionality, beyond the included
+portions of the CONTAINER.
+
+b. The following notice shall be included in modifications and derivative works of source code
+distributed: “This software contains source code provided by NVIDIA Corporation.”
+
+c. You agree to distribute the CONTAINER subject to the terms at least as protective as the terms of
+this license, including (without limitation) terms relating to the license grant, license
+restrictions and protection of NVIDIA’s intellectual property rights. Additionally, you agree that
+you will protect the privacy, security and legal rights of your application users.
+
+d. You agree to notify NVIDIA in writing of any known or suspected distribution or use of the
+CONTAINER not in compliance with the requirements of this license, and to enforce the terms of your
+agreements with respect to the distributed CONTAINER.
+
+3. AUTHORIZED USERS. You may allow employees and contractors of your entity or of your
+subsidiary(ies) to access and use the CONTAINER from your secure network to perform work on your
+behalf. If you are an academic institution you may allow users enrolled or employed by the academic
+institution to access and use the CONTAINER from your secure network. You are responsible for the
+compliance with the terms of this license by your authorized users.
+
+4. LIMITATIONS. Your license to use the CONTAINER is restricted as follows:
+
+a. The CONTAINER is licensed for you to develop services and applications only for their use in
+systems with NVIDIA GPUs.
+
+b. You may not reverse engineer, decompile or disassemble, or remove copyright or other proprietary
+notices from any portion of the CONTAINER or copies of the CONTAINER.
+
+c. Except as expressly provided in this license, you may not copy, sell, rent, sublicense, transfer,
+distribute, modify, or create derivative works of any portion of the CONTAINER. For clarity, you may
+not distribute or sublicense the CONTAINER as a stand-alone product.
+
+d. Unless you have an agreement with NVIDIA for this purpose, you may not indicate that a service or
+an application created with the CONTAINER is sponsored or endorsed by NVIDIA.
+
+e. You may not bypass, disable, or circumvent any technical limitation, encryption, security,
+digital rights management or authentication mechanism in the CONTAINER.
+
+f. You may not replace any NVIDIA software components in the CONTAINER that are governed by this
+license with other software that implements NVIDIA APIs.
+
+g. You may not use the CONTAINER in any manner that would cause it to become subject to an open
+source software license. As examples, licenses that require as a condition of use, modification,
+and/or distribution that the CONTAINER be: (i) disclosed or distributed in source code form; (ii)
+licensed for the purpose of making derivative works; or (iii) redistributable at no charge.
+
+h. Unless you have an agreement with NVIDIA for this purpose, you may not use the CONTAINER with any
+system or application where the use or failure of the system or application can reasonably be
+expected to threaten or result in personal injury, death, or catastrophic loss. Examples include use
+in avionics, navigation, military, medical, life support or other life critical applications. NVIDIA
+does not design, test or manufacture the CONTAINER for these critical uses and NVIDIA shall not be
+liable to you or any third party, in whole or in part, for any claims or damages arising from such
+uses.
+
+i. You agree to defend, indemnify and hold harmless NVIDIA and its affiliates, and their respective
+employees, contractors, agents, officers and directors, from and against any and all claims,
+damages, obligations, losses, liabilities, costs or debt, fines, restitutions and expenses
+(including but not limited to attorney’s fees and costs incident to establishing the right of
+indemnification) arising out of or related to your use of the CONTAINER outside of the scope of this
+license, or not in compliance with its terms.
+
+5. UPDATES. NVIDIA may, at its option, make available patches, workarounds or other updates to this
+CONTAINER. Unless the updates are provided with their separate governing terms, they are deemed part
+of the CONTAINER licensed to you as provided in this license. You agree that the form and content of
+the CONTAINER that NVIDIA provides may change without prior notice to you. While NVIDIA generally
+maintains compatibility between versions, NVIDIA may in some cases make changes that introduce
+incompatibilities in future versions of the CONTAINER.
+
+6. PRE-RELEASE VERSIONS. CONTAINER versions identified as alpha, beta, preview, early access or
+otherwise as pre-release may not be fully functional, may contain errors or design flaws, and may
+have reduced or different security, privacy, availability, and reliability standards relative to
+commercial versions of NVIDIA software and materials. You may use a pre-release CONTAINER version at
+your own risk, understanding that these versions are not intended for use in production or
+business-critical systems. NVIDIA may choose not to make available a commercial version of any
+pre-release CONTAINER. NVIDIA may also choose to abandon development and terminate the availability
+of a pre-release CONTAINER at any time without liability.
+
+7. THIRD-PARTY COMPONENTS. The CONTAINER may include third-party components with separate legal
+notices or terms as may be described in proprietary notices accompanying the CONTAINER. If and to
+the extent there is a conflict between the terms in this license and the third-party license terms,
+the third-party terms control only to the extent necessary to resolve the conflict.
+
+You acknowledge and agree that it is your sole responsibility to obtain any additional third-party
+licenses required to make, have made, use, have used, sell, import, and offer for sale your products
+or services that include or incorporate any third-party software and content relating to audio
+and/or video encoders and decoders from, including but not limited to, Microsoft, Thomson,
+Fraunhofer IIS, Sisvel S.p.A., MPEG-LA, and Coding Technologies. NVIDIA does not grant to you under
+this license any necessary patent or other rights with respect to any audio and/or video encoders
+and decoders.
+
+Subject to the other terms of this license, you may use the CONTAINER to develop and test
+applications released under Open Source Initiative (OSI) approved open source software licenses.
+
+8. OWNERSHIP.
+
+8.1 NVIDIA reserves all rights, title and interest in and to the CONTAINER not expressly granted to
+you under this license. NVIDIA and its suppliers hold all rights, title and interest in and to the
+CONTAINER, including their respective intellectual property rights. The CONTAINER is copyrighted and
+protected by the laws of the United States and other countries, and international treaty provisions.
+
+8.2 Subject to the rights of NVIDIA and its suppliers in the CONTAINER, you hold all rights, title
+and interest in and to your services, applications and your derivative works of the sample source
+code delivered in the CONTAINER including their respective intellectual property rights.
+
+9. FEEDBACK. You may, but are not obligated to, provide to NVIDIA suggestions, fixes, modifications,
+feature requests or other feedback regarding the CONTAINER (“Feedback”). Feedback, even if
+designated as confidential by you, shall not create any confidentiality obligation for NVIDIA.
+NVIDIA and its designees have a perpetual, non-exclusive, worldwide, irrevocable license to use,
+reproduce, publicly display, modify, create derivative works of, license, sublicense, and otherwise
+distribute and exploit Feedback as NVIDIA sees fit without payment and without obligation or
+restriction of any kind on account of intellectual property rights or otherwise.
+
+10. NO WARRANTIES. THE CONTAINER IS PROVIDED AS-IS. TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE
+LAW NVIDIA AND ITS AFFILIATES EXPRESSLY DISCLAIM ALL WARRANTIES OF ANY KIND OR NATURE, WHETHER
+EXPRESS, IMPLIED OR STATUTORY, INCLUDING, BUT NOT LIMITED TO, WARRANTIES OF MERCHANTABILITY,
+NON-INFRINGEMENT, OR FITNESS FOR A PARTICULAR PURPOSE. NVIDIA DOES NOT WARRANT THAT THE CONTAINER
+WILL MEET YOUR REQUIREMENTS OR THAT THE OPERATION THEREOF WILL BE UNINTERRUPTED OR ERROR-FREE, OR
+THAT ALL ERRORS WILL BE CORRECTED.
+
+11. LIMITATIONS OF LIABILITY. TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW NVIDIA AND ITS
+AFFILIATES SHALL NOT BE LIABLE FOR ANY SPECIAL, INCIDENTAL, PUNITIVE OR CONSEQUENTIAL DAMAGES, OR
+FOR ANY LOST PROFITS, PROJECT DELAYS, LOSS OF USE, LOSS OF DATA OR LOSS OF GOODWILL, OR THE COSTS OF
+PROCURING SUBSTITUTE PRODUCTS, ARISING OUT OF OR IN CONNECTION WITH THIS LICENSE OR THE USE OR
+PERFORMANCE OF THE CONTAINER, WHETHER SUCH LIABILITY ARISES FROM ANY CLAIM BASED UPON BREACH OF
+CONTRACT, BREACH OF WARRANTY, TORT (INCLUDING NEGLIGENCE), PRODUCT LIABILITY OR ANY OTHER CAUSE OF
+ACTION OR THEORY OF LIABILITY, EVEN IF NVIDIA HAS PREVIOUSLY BEEN ADVISED OF, OR COULD REASONABLY
+HAVE FORESEEN, THE POSSIBILITY OF SUCH DAMAGES. IN NO EVENT WILL NVIDIA’S AND ITS AFFILIATES TOTAL
+CUMULATIVE LIABILITY UNDER OR ARISING OUT OF THIS LICENSE EXCEED US$10.00. THE NATURE OF THE
+LIABILITY OR THE NUMBER OF CLAIMS OR SUITS SHALL NOT ENLARGE OR EXTEND THIS LIMIT.
+
+12. TERMINATION. Your rights under this license will terminate automatically without notice from
+NVIDIA if you fail to comply with any term and condition of this license or if you commence or
+participate in any legal proceeding against NVIDIA with respect to the CONTAINER. NVIDIA may
+terminate this license with advance written notice to you, if NVIDIA decides to no longer provide
+the CONTAINER in a country or, in NVIDIA’s sole discretion, the continued use of it is no longer
+commercially viable. Upon any termination of this license, you agree to promptly discontinue use of
+the CONTAINER and destroy all copies in your possession or control. Your prior distributions in
+accordance with this license are not affected by the termination of this license. All provisions of
+this license will survive termination, except for the license granted to you.
+
+13. APPLICABLE LAW. This license will be governed in all respects by the laws of the United States
+and of the State of Delaware, without regard to the conflicts of laws principles. The United Nations
+Convention on Contracts for the International Sale of Goods is specifically disclaimed. You agree to
+all terms of this license in the English language. The state or federal courts residing in Santa
+Clara County, California shall have exclusive jurisdiction over any dispute or claim arising out of
+this license. Notwithstanding this, you agree that NVIDIA shall still be allowed to apply for
+injunctive remedies or urgent legal relief in any jurisdiction.
+
+14. NO ASSIGNMENT. This license and your rights and obligations thereunder may not be assigned by
+you by any means or operation of law without NVIDIA’s permission. Any attempted assignment not
+approved by NVIDIA in writing shall be void and of no effect. NVIDIA may assign, delegate or
+transfer this license and its rights and obligations, and if to a non-affiliate you will be
+notified.
+
+15. EXPORT. The CONTAINER is subject to United States export laws and regulations. You agree to
+comply with all applicable
+
+U.S. and international export laws, including the Export Administration Regulations (EAR)
+administered by the U.S. Department of Commerce and economic sanctions administered by the U.S.
+Department of Treasury’s Office of Foreign Assets Control (OFAC). These laws include restrictions on
+destinations, end-users and end-use. By accepting this license, you confirm that you are not
+currently residing in a country or region currently embargoed by the U.S. and that you are not
+otherwise prohibited from receiving the CONTAINER.
+
+16. GOVERNMENT USE. The CONTAINER is, and shall be treated as being, “Commercial Items” as that term
+is defined at 48 CFR § 2.101, consisting of “commercial computer software” and “commercial computer
+software documentation”, respectively, as such terms are used in, respectively, 48 CFR § 12.212 and
+48 CFR §§ 227.7202 & 252.227-7014(a)(1). Use, duplication or disclosure by the U.S. Government or a
+U.S. Government subcontractor is subject to the restrictions in this license pursuant to 48 CFR §
+12.212 or 48 CFR § 227.7202. In no event shall the US Government user acquire rights in the
+CONTAINER beyond those specified in 48 C.F.R. 52.227-19(b)(1)-(2).
+
+17. NOTICES. Please direct your legal notices or other correspondence to NVIDIA Corporation, 2788
+San Tomas Expressway, Santa Clara, California 95051, United States of America, Attention: Legal
+Department.
+
+18. ENTIRE AGREEMENT. This license is the final, complete and exclusive agreement between the
+parties relating to the subject matter of this license and supersedes all prior or contemporaneous
+understandings and agreements relating to this subject matter, whether oral or written. If any court
+of competent jurisdiction determines that any provision of this license is illegal, invalid or
+unenforceable, the remaining provisions will remain in full force and effect. Any amendment or
+waiver under this license shall be in writing and signed by representatives of both parties.
+
+19. LICENSING. If the distribution terms in this license are not suitable for your organization, or
+for any questions regarding this license, please contact NVIDIA at nvidia-compute-license-questions@nvidia.com.
+
+(v. December 4, 2020)

--- a/docker/run.bash
+++ b/docker/run.bash
@@ -22,7 +22,7 @@
 #   docker
 #   nvidia-docker
 #   an X server
-# Recommended:
+# Optional:
 #   A joystick mounted to /dev/input/js0 or /dev/input/js1
 
 if [ $# -lt 1 ]

--- a/docker/run.bash
+++ b/docker/run.bash
@@ -41,7 +41,7 @@ WORKSPACES=("${ARGS[@]:1}")
 XAUTH=/tmp/.docker.xauth
 if [ ! -f $XAUTH ]
 then
-    xauth_list=$(xauth nlist :0 | sed -e 's/^..../ffff/')
+    xauth_list=$(xauth nlist $DISPLAY | sed -e 's/^..../ffff/')
     if [ ! -z "$xauth_list" ]
     then
         echo $xauth_list | xauth -f $XAUTH nmerge -

--- a/docker/run.bash
+++ b/docker/run.bash
@@ -31,6 +31,30 @@ then
     exit 1
 fi
 
+# Default to NVIDIA
+DOCKER_OPTS="--runtime=nvidia"
+
+# Parse and remove args
+PARAMS=""
+while (( "$#" )); do
+  case "$1" in
+    --no-nvidia)
+        DOCKER_OPTS=""
+      shift
+      ;;
+    -*|--*=) # unsupported flags
+      echo "Error: Unsupported flag $1" >&2
+      exit 1
+      ;;
+    *) # preserve positional arguments
+      PARAMS="$PARAMS $1"
+      shift
+      ;;
+  esac
+done
+# set positional arguments in their proper place
+eval set -- "$PARAMS"
+
 IMG=$(basename $1)
 
 ARGS=("$@")
@@ -50,8 +74,6 @@ then
     fi
     chmod a+r $XAUTH
 fi
-
-DOCKER_OPTS=
 
 # Share your vim settings.
 VIMRC=~/.vimrc
@@ -92,7 +114,6 @@ docker run -it \
   -v "/dev/input:/dev/input" \
   --privileged \
   --rm \
-  --runtime=nvidia \
   --security-opt seccomp=unconfined \
   --ipc=host \
   --network=host \

--- a/docker/run.bash
+++ b/docker/run.bash
@@ -81,6 +81,7 @@ done
 # E.g.:
 # -v "/opt/sublime_text:/opt/sublime_text" \
 
+# --ipc=host and --network=host are needed for no-NVIDIA Dockerfile to work
 docker run -it \
   -e DISPLAY \
   -e QT_X11_NO_MITSHM=1 \
@@ -93,5 +94,7 @@ docker run -it \
   --rm \
   --runtime=nvidia \
   --security-opt seccomp=unconfined \
+  --ipc=host \
+  --network=host \
   $DOCKER_OPTS \
   $IMG

--- a/docker/run.bash
+++ b/docker/run.bash
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+
+#
+# Copyright (C) 2023 Open Source Robotics Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+
+# Runs a docker container with the image created by build.bash
+# Requires:
+#   docker
+#   nvidia-docker
+#   an X server
+# Recommended:
+#   A joystick mounted to /dev/input/js0 or /dev/input/js1
+
+if [ $# -lt 1 ]
+then
+    echo "Usage: $0 <docker image> [<dir with workspace> ...]"
+    exit 1
+fi
+
+IMG=$(basename $1)
+
+ARGS=("$@")
+WORKSPACES=("${ARGS[@]:1}")
+
+# Make sure processes in the container can connect to the x server
+# Necessary so gazebo can create a context for OpenGL rendering (even headless)
+XAUTH=/tmp/.docker.xauth
+if [ ! -f $XAUTH ]
+then
+    xauth_list=$(xauth nlist :0 | sed -e 's/^..../ffff/')
+    if [ ! -z "$xauth_list" ]
+    then
+        echo $xauth_list | xauth -f $XAUTH nmerge -
+    else
+        touch $XAUTH
+    fi
+    chmod a+r $XAUTH
+fi
+
+DOCKER_OPTS=
+
+# Share your vim settings.
+VIMRC=~/.vimrc
+if [ -f $VIMRC ]
+then
+  DOCKER_OPTS="$DOCKER_OPTS -v $VIMRC:/home/developer/.vimrc:ro"
+fi
+
+# Mabel: Share your custom terminal setup commands
+GITCONFIG=~/.gitconfig
+DOCKER_OPTS="$DOCKER_OPTS -v $GITCONFIG:/home/developer/.gitconfig:ro"
+
+for WS_DIR in ${WORKSPACES[@]}
+do
+  WS_DIRNAME=$(basename $WS_DIR)
+  if [ ! -d $WS_DIR/src ]
+  then
+    echo "Other! $WS_DIR"
+    DOCKER_OPTS="$DOCKER_OPTS -v $WS_DIR:/home/developer/other/$WS_DIRNAME"
+  else
+    echo "Workspace! $WS_DIR"
+    DOCKER_OPTS="$DOCKER_OPTS -v $WS_DIR:/home/developer/workspaces/$WS_DIRNAME"
+  fi
+done
+
+# Mount extra volumes if needed.
+# E.g.:
+# -v "/opt/sublime_text:/opt/sublime_text" \
+
+docker run -it \
+  -e DISPLAY \
+  -e QT_X11_NO_MITSHM=1 \
+  -e XAUTHORITY=$XAUTH \
+  -v "$XAUTH:$XAUTH" \
+  -v "/tmp/.X11-unix:/tmp/.X11-unix" \
+  -v "/etc/localtime:/etc/localtime:ro" \
+  -v "/dev/input:/dev/input" \
+  --privileged \
+  --rm \
+  --runtime=nvidia \
+  --security-opt seccomp=unconfined \
+  $DOCKER_OPTS \
+  $IMG

--- a/docker/run.bash
+++ b/docker/run.bash
@@ -68,6 +68,7 @@ then
     xauth_list=$(xauth nlist $DISPLAY | sed -e 's/^..../ffff/')
     if [ ! -z "$xauth_list" ]
     then
+        touch $XAUTH
         echo $xauth_list | xauth -f $XAUTH nmerge -
     else
         touch $XAUTH


### PR DESCRIPTION
Initial Dockerfile with NVIDIA + ROS 2 Humble + Gazebo Garden binary installs.

To test, follow README.md.

## Future work

- ~~We'll need to add instructions for installing nvidia-docker2, which we can just point to the SubT instructions https://github.com/osrf/subt/wiki/Docker%20Install~~
   Or if we want to make this repo self-contained, we can steal from SubT.
   Update: Added link to README

- ~~We'll hopefully have an alternative Docker image for machines without NVIDIA card, [using Mesa's LLVMpipe to do software rendering](https://github.com/gazebosim/gz-rendering/blob/gz-rendering7/.github/ci/after_make.sh#L7-L9)~~ Update: done.