### PR TITLE
Add ROS 2 documentation to the image

### DIFF
--- a/docker/icra2023_tutorial/Dockerfile
+++ b/docker/icra2023_tutorial/Dockerfile
@@ -112,6 +112,5 @@ RUN cd /home/$USERNAME && git clone https://github.com/ros2/ros2_documentation &
  && cp -av /home/$USERNAME/ros2_documentation/build/html/* /home/$USERNAME/docs.ros.org \
  && rm -rf /home/$USERNAME/ros2_documentation
 
-# Install a start.bash script which will start a webserver on 9090 for the ROS 2 documentation
-RUN /bin/bash -c "echo -e 'pushd /home/$USERNAME/docs.ros.org && python3 -m http.server 9090 >& /dev/null &\n/bin/bash' > /home/$USERNAME/start.bash" && chmod +x /home/$USERNAME/start.bash
-CMD ["/bin/bash", "-c", "/home/$USERNAME/start.bash"]
+# Start a webserver on localhost:9090 for the ROS 2 documentation, and drop to a bash shell
+CMD ["/bin/bash", "-c", "pushd /home/$USERNAME/docs.ros.org && python3 -m http.server 9090 >& /dev/null & /bin/bash"]

--- a/docker/icra2023_tutorial/Dockerfile
+++ b/docker/icra2023_tutorial/Dockerfile
@@ -113,5 +113,5 @@ RUN cd /home/$USERNAME && git clone https://github.com/ros2/ros2_documentation &
  && rm -rf /home/$USERNAME/ros2_documentation
 
 # Install a start.bash script which will start a webserver on 9090 for the ROS 2 documentation
-RUN /bin/bash -c "echo -e '#!/bin/bash\npushd /home/$USERNAME/docs.ros.org && python3 -m http.server 9090 >& /dev/null &\n/bin/bash' > /home/$USERNAME/start.bash" && chmod +x /home/$USERNAME/start.bash
-CMD /home/$USERNAME/start.bash
+RUN /bin/bash -c "echo -e 'pushd /home/$USERNAME/docs.ros.org && python3 -m http.server 9090 >& /dev/null &\n/bin/bash' > /home/$USERNAME/start.bash" && chmod +x /home/$USERNAME/start.bash
+CMD ["/bin/bash", "-c", "/home/$USERNAME/start.bash"]

--- a/docker/icra2023_tutorial/Dockerfile
+++ b/docker/icra2023_tutorial/Dockerfile
@@ -104,3 +104,14 @@ RUN useradd -U --uid ${user_id} -ms /bin/bash $USERNAME \
 USER $USERNAME
 # When running a container start in the developer's home folder
 WORKDIR /home/$USERNAME
+
+# Build and install the ROS 2 documentation
+RUN cd /home/$USERNAME && git clone https://github.com/ros2/ros2_documentation && cd ros2_documentation \
+ && pip3 install -r requirements.txt && PATH=$PATH:/home/$USERNAME/.local/bin make multiversion \
+ && mkdir /home/$USERNAME/docs.ros.org \
+ && cp -av /home/$USERNAME/ros2_documentation/build/html/* /home/$USERNAME/docs.ros.org \
+ && rm -rf /home/$USERNAME/ros2_documentation
+
+# Install a start.bash script which will start a webserver on 9090 for the ROS 2 documentation
+RUN /bin/bash -c "echo -e '#!/bin/bash\npushd /home/$USERNAME/docs.ros.org && python3 -m http.server 9090 >& /dev/null &\n/bin/bash' > /home/$USERNAME/start.bash" && chmod +x /home/$USERNAME/start.bash
+CMD /home/$USERNAME/start.bash


### PR DESCRIPTION
These commands add the ROS 2 documentation to the image, as well as run a simple web server to serve it locally on http://localhost:9090
