### PR TITLE
Update Docker scripts and README to DockerHub image names

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This repository will be updated in the time leading up to the conference.
 
 [Overview](#overview)
 
+[Quick Start](#quick-start)
+
 [Contributing](#contributing)
 
 [Schedule](#schedule)
@@ -34,6 +36,15 @@ Audience:
 - Gazebo-classic users wondering whether to migrate to new Gazebo
 - Users wondering whether the new Gazebo is right for them
 - Users of other simulators looking to learn about the new Gazebo and existing infrastructure we worked on with Nvidia, DeepMind, and Toyota Research Institute in the past few years to handle format conversions between SDF and formats used by OmniVerse, MuJoCo, and Drake.
+
+## Quick Start
+
+Clone this repository:
+```
+git clone https://github.com/osrf/icra2023_ros2_gz_tutorial.git
+```
+
+Follow the installation instructions in [`docker/README.md`](https://github.com/osrf/icra2023_ros2_gz_tutorial/blob/main/docker/README.md) to get set up and running.
 
 ## Contributing
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -54,9 +54,21 @@ DockerHub or built locally:
 ./run.bash osrf/icra2023_ros2_gz_tutorial:tutorial_no_nvidia --no-nvidia
 ```
 
-If you built the image locally, this is a shorter, equivalent command:
+For convenience, if you built the image locally, this is an equivalent command
+that you can tab-complete:
 ```
 ./run.bash icra2023_tutorial
+```
+
+You can see the list of all images with
+```
+docker images
+```
+
+You can set up an alias so that you don't have to type the command every time.
+For example, replace the path and image name to yours:
+```
+alias run_osrf_icra="/absolute/path/to/run.bash osrf/icra2023_ros2_gz_tutorial:tutorial_nvidia"
 ```
 
 ## Open another terminal in the running container

--- a/docker/README.md
+++ b/docker/README.md
@@ -2,11 +2,14 @@
 
 ## Prerequisites
 
+These instructions were tested on Ubuntu Jammy (22.04). Other recent versions
+should work as well.
+
 If your machine has an NVIDIA GPU, install Docker and NVIDIA Docker 2 following
 instructions [here](https://github.com/osrf/subt/wiki/Docker%20Install).
 
 If you don't have an NVIDIA GPU, Gazebo GUI will use software rendering via
-Mesa llvmpipe (you can check that in ~/.gz/rendering/ogre2.log after starting
+Mesa llvmpipe (you can check that in `~/.gz/rendering/ogre2.log` after starting
 the Gazebo GUI).
 
 ## Pull from DockerHub

--- a/docker/README.md
+++ b/docker/README.md
@@ -9,24 +9,54 @@ If you don't have an NVIDIA GPU, Gazebo GUI will use software rendering via
 Mesa llvmpipe (you can check that in ~/.gz/rendering/ogre2.log after starting
 the Gazebo GUI).
 
-## Example usage
+## Pull from DockerHub
 
-To build an image:
+This image (and possibly some extra data) is built and pushed to DockerHub under
+[osrf/icra2023_ros2_gz_tutorial](https://hub.docker.com/r/osrf/icra2023_ros2_gz_tutorial/tags).
+
+You can pull it from DockerHub and skip building it locally:
+```
+docker pull osrf/icra2023_ros2_gz_tutorial:<tag>
+```
+Replace `<tag>` with `tutorial_nvidia` or `tutorial_no_nvidia`, depending on whether you
+have an NVIDIA GPU.
+
+## Build the image locally
+
+Skip this step if you already pulled the image from DockerHub.
 
 If you have an NVIDIA graphics card, build using the NVIDIA Docker base image:
 ```
 ./build.bash nvidia_opengl_ubuntu22
 ./build.bash icra2023_tutorial
 ```
+
 Otherwise, build without NVIDIA Docker:
 ```
 ./build.bash icra2023_tutorial --no-nvidia
 ```
 
-To spin up a container from an image:
+A few tags will be created for the same image, for convenience of running
+commands.
+
+## Run the image
+
+To spin up a container from an image, this should work whether you pulled from
+DockerHub or built locally:
+```
+# If you have NVIDIA GPU
+./run.bash osrf/icra2023_ros2_gz_tutorial:tutorial_nvidia
+
+# Without NVIDIA GPU
+./run.bash osrf/icra2023_ros2_gz_tutorial:tutorial_no_nvidia --no-nvidia
+```
+
+If you built the image locally, this is a shorter, equivalent command:
 ```
 ./run.bash icra2023_tutorial
 ```
+
+## Open another terminal in the running container
 
 To join a running container from another terminal:
 ```
@@ -53,6 +83,13 @@ Gazebo:
 gz sim
 ```
 The Gazebo GUI should show up.
+
+## Look at ROS 2 documentation locally
+
+The ROS 2 documentaion is built locally in the Dockerfile.
+
+Open a web browser and go to `localhost:9090`. You should see the documentation
+site.
 
 ## Docker cheat sheet
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -128,3 +128,22 @@ If GUI programs don't work, you can also try the following on the host machine:
 ```
 xhost + local:
 ```
+
+### ROS 2 Humble and Gazebo Garden interoperability
+
+For the purpose of the ICRA tutorial, we set up ROS 2 and Gazebo separately,
+since they are run as two separate tutorials.
+This allows us to show you the latest versions of each at the time of writing
+(ROS 2 Humble and Gazebo Garden).
+We do not intend to use both at the same time for the tutorial.
+
+It is possible to use Humble and Garden together, and we have real-world
+projects that do, though that is not a recommended combination.
+
+Make sure to export this environment variable:
+```
+export GZ_VERSION=garden
+```
+
+For details, see Gazebo documentation on
+[Installing Gazebo with ROS](https://gazebosim.org/docs/garden/ros_installation).

--- a/docker/README.md
+++ b/docker/README.md
@@ -140,7 +140,10 @@ We do not intend to use both at the same time for the tutorial.
 It is possible to use Humble and Garden together, and we have real-world
 projects that do, though that is not a recommended combination.
 
-Make sure to export this environment variable:
+You will need to build the interface stack
+[`ros_gz`](https://github.com/gazebosim/ros_gz) from source.
+
+Then, make sure to export this environment variable:
 ```
 export GZ_VERSION=garden
 ```

--- a/docker/build.bash
+++ b/docker/build.bash
@@ -36,7 +36,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # Default base image, defined in nvidia_opengl_ubuntu22/Dockerfile
 base="nvidia_opengl_ubuntu22:latest"
-image_suffix="_nvidia"
+tag_suffix="_nvidia"
 
 # Parse and remove args
 PARAMS=""
@@ -44,7 +44,7 @@ while (( "$#" )); do
   case "$1" in
     --no-nvidia)
       base="ubuntu:jammy"
-      image_suffix="_no_nvidia"
+      tag_suffix="_no_nvidia"
       shift
       ;;
     -*|--*=) # unsupported flags
@@ -68,14 +68,18 @@ fi
 
 user_id=$(id -u)
 image_name=$(basename $1)
-#image_plus_tag=$image_name:$(date +%Y_%b_%d_%H%M)
-# Tag as latest so don't have a dozen uniquely timestamped images hanging around
+
+# Use same name as source directory so can tab-complete on run.bash
 image_plus_tag=$image_name:latest
 
 echo "Building $image_name with base image $base"
 docker build --rm -t $image_plus_tag --build-arg base=$base --build-arg user_id=$user_id $DIR/$image_name
 echo "Built $image_plus_tag"
 
-# Extra tag in case you have both the NVIDIA and no-NVIDIA images
-docker tag $image_plus_tag $image_name$image_suffix:latest
-echo "Tagged as $image_name$image_suffix:latest"
+# If building the tutorial image
+if [[ "$image_name" == icra2023_tutorial ]]; then
+  # DockerHub repo name
+  repo_plus_tag_suffix="osrf/icra2023_ros2_gz_tutorial:tutorial$tag_suffix"
+  docker tag $image_plus_tag $repo_plus_tag_suffix
+  echo "Tagged as $repo_plus_tag_suffix"
+fi

--- a/docker/run.bash
+++ b/docker/run.bash
@@ -55,7 +55,15 @@ done
 # set positional arguments in their proper place
 eval set -- "$PARAMS"
 
-IMG=$(basename $1)
+# Works for image names containing "/" character, but cannot run from another
+# directory
+IMG="$1"
+#IMG=$(basename $1)
+# Truncate last "/" in case using bash-complete for directory name
+if [[ $IMG == */ ]]; then
+  IMG=${IMG::-1}
+fi
+echo $IMG
 
 ARGS=("$@")
 WORKSPACES=("${ARGS[@]:1}")


### PR DESCRIPTION
I tested this. The commands in README should work with the new updates to the scripts.

Also added to README
- DockerHub URL
- `localhost:9090` added in #15 
- Troubleshoot section in case people want to use ROS 2 and Gazebo together
- Quick start section on main page