### PR TITLE
Update installation instructions for Docker

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -2,8 +2,18 @@
 
 ## Prerequisites
 
-If your machine has an NVIDIA GPU, install Docker and NVIDIA Docker 2 following
-instructions [here](https://github.com/osrf/subt/wiki/Docker%20Install).
+Before starting, please ensure that Docker is installed and configured on your
+system by following the instructions
+[here](https://github.com/osrf/subt/wiki/Docker%20Install).
+
+While following the instructions, please add your user account to the docker
+group in order to avoid permission issues by following the instructions under
+the Troubleshooting section
+[here](https://github.com/osrf/subt/wiki/Docker%20Install#troubleshooting).
+
+If your machine has an NVIDIA GPU, make sure to also install NVIDIA Docker 2
+following the instructions
+[here](https://github.com/osrf/subt/wiki/Docker%20Install#install-nvidia-docker).
 
 If you don't have an NVIDIA GPU, Gazebo GUI will use software rendering via
 Mesa llvmpipe (you can check that in ~/.gz/rendering/ogre2.log after starting


### PR DESCRIPTION
This PR updates `docker/README.md#Prerequisites` to make the Docker installation instructions more explicit for participants regardless of their GPU, as discussed under #14.

It also adds a mention about configuring Docker for a non-root user because the current helper scripts (`build.bash` / `run.bash` / `join.bash`) require such setup and would fail otherwise. One of the troubleshooting sections of the same SubT wiki page is used as a reference.

Do you think that is enough? An alternative would be to update the scripts to run the `docker ...` commands with `sudo` if it would fail otherwise.