### PR TITLE
Update run.bash to use --gpus all when possible

### DIFF
--- a/docker/run.bash
+++ b/docker/run.bash
@@ -32,6 +32,9 @@ then
 fi
 
 # Default to NVIDIA
+# Note that on all non-Debian/non-Ubuntu platforms, dpkg won't exist so they'll always choose
+# --runtime=nvidia.  If you are running one of those platforms and --runtime=nvidia doesn't work
+# for you, change the else statement.
 if [[ -x "$(command -v dpkg)" ]] && dpkg --compare-versions "$(docker version --format '{{.Server.Version}}')" gt "19.3"; then
   DOCKER_OPTS="--gpus=all"
 else

--- a/docker/run.bash
+++ b/docker/run.bash
@@ -32,7 +32,11 @@ then
 fi
 
 # Default to NVIDIA
-DOCKER_OPTS="--runtime=nvidia"
+if [[ -x "$(command -v dpkg)" ]] && dpkg --compare-versions "$(docker version --format '{{.Server.Version}}')" gt "19.3"; then
+  DOCKER_OPTS="--gpus=all"
+else
+  DOCKER_OPTS="--runtime=nvidia"
+fi
 
 # Parse and remove args
 PARAMS=""


### PR DESCRIPTION
This PR changes `docker/run.bash` to use `--gpus=all` instead of `--runtime=nvidia` for Docker version `>19.3` (to enable NVIDIA GPUs). PR is based on one of the discussions in #14, but it is not confirmed if this is a better option. What do you think about this change?

For more context, the following comment describes the difference between `nvidia-docker2` and `nvidia-container-toolkit` in depth: https://github.com/NVIDIA/nvidia-docker/issues/1268#issuecomment-632692949

Regarding this PR, the condition utilizes `dpkg` for version comparison. If `dpkg` is not detected on the system, then `--runtime=nvidia` is used as a fallback option. Similarly, `--runtime=nvidia` is used if Docker with version `<=19.3.0` is installed.

---

On a side note, I often need to export these environment variables inside Docker containers to use NVIDIA GPU for certain applications. Do you think it is worth adding them to be on the safe side? (I don't know if setting these variables is too permissive or if it brings some disadvantages)

```bash
NVIDIA_VISIBLE_DEVICES="all"
NVIDIA_DRIVER_CAPABILITIES="all"
```
