### PR TITLE
Synchronize ROS 2 and Gazebo ENVs with the host (Default to isolated communication)

### DIFF
--- a/docker/run.bash
+++ b/docker/run.bash
@@ -100,6 +100,18 @@ do
   fi
 done
 
+# Synchronize ROS 2 and Gazebo transport environment variables with the host
+# Default to isolated communication
+ROS_ENVS=(
+  "ROS_DOMAIN_ID=${ROS_DOMAIN_ID:-"0"}"
+  "ROS_LOCALHOST_ONLY=${ROS_LOCALHOST_ONLY:-"1"}"
+)
+GZ_ENVS=(
+  "GZ_IP=${GZ_IP:-"127.0.0.1"}"
+  "GZ_RELAY=${GZ_RELAY:-"127.0.0.1"}"
+)
+DOCKER_OPTS="${DOCKER_OPTS} ${ROS_ENVS[*]/#/"-e "} ${GZ_ENVS[*]/#/"-e "}"
+
 # Mount extra volumes if needed.
 # E.g.:
 # -v "/opt/sublime_text:/opt/sublime_text" \


### PR DESCRIPTION
This PR updates `docker/run.bash` to set environment variables for ROS 2 and Gazebo transport inside the Docker container.

By default, the following options are appended to `DOCKER_OPTS` in the updated script with the purpose of isolating communication among participants that share the same local network (because `--network=host` is being used).
```bash
-e ROS_DOMAIN_ID=0 -e ROS_LOCALHOST_ONLY=1 -e GZ_IP=127.0.0.1 -e GZ_RELAY=127.0.0.1
```

However, these are just the default values. If any of these environment variables are exported/set when running the updated `run.bash` script, the same value will be used inside the container. For example,
```bash
ROS_DOMAIN_ID=5 docker/run.bash icra2023_tutorial
```
will result in `-e ROS_DOMAIN_ID=5` being passed into the `docker run ...` command.

I am not sure if this synchronization with the host is needed. Maybe it is better to hard-code the values for the isolated scenario? There's also the option to set these values inside `Dockerfile` as `ENV` layers, which might have some advantages. What do you think?

Note: I have NOT tested this with multiple machines yet.