### PR TITLE
Print error if USER is not in the docker group

### DIFF
--- a/docker/build.bash
+++ b/docker/build.bash
@@ -66,13 +66,6 @@ then
   exit 2
 fi
 
-# If the user is not in the docker group, run the docker command with sudo
-if [[ $(grep /etc/group -e "docker") == *"${USER}"* ]]; then
-  DOCKER_CMD_PREFIX=""
-else
-  DOCKER_CMD_PREFIX="sudo"
-fi
-
 user_id=$(id -u)
 image_name=$(basename $1)
 
@@ -80,13 +73,13 @@ image_name=$(basename $1)
 image_plus_tag=$image_name:latest
 
 echo "Building $image_name with base image $base"
-${DOCKER_CMD_PREFIX} docker build --rm -t $image_plus_tag --build-arg base=$base --build-arg user_id=$user_id $DIR/$image_name
+docker build --rm -t $image_plus_tag --build-arg base=$base --build-arg user_id=$user_id $DIR/$image_name
 echo "Built $image_plus_tag"
 
 # If building the tutorial image
 if [[ "$image_name" == icra2023_tutorial ]]; then
   # DockerHub repo name
   repo_plus_tag_suffix="osrf/icra2023_ros2_gz_tutorial:tutorial$tag_suffix"
-  ${DOCKER_CMD_PREFIX} docker tag $image_plus_tag $repo_plus_tag_suffix
+  docker tag $image_plus_tag $repo_plus_tag_suffix
   echo "Tagged as $repo_plus_tag_suffix"
 fi

--- a/docker/build.bash
+++ b/docker/build.bash
@@ -66,6 +66,13 @@ then
   exit 2
 fi
 
+# If the user is not in the docker group, run the docker command with sudo
+if [[ $(grep /etc/group -e "docker") == *"${USER}"* ]]; then
+  DOCKER_CMD_PREFIX=""
+else
+  DOCKER_CMD_PREFIX="sudo"
+fi
+
 user_id=$(id -u)
 image_name=$(basename $1)
 
@@ -73,13 +80,13 @@ image_name=$(basename $1)
 image_plus_tag=$image_name:latest
 
 echo "Building $image_name with base image $base"
-docker build --rm -t $image_plus_tag --build-arg base=$base --build-arg user_id=$user_id $DIR/$image_name
+${DOCKER_CMD_PREFIX} docker build --rm -t $image_plus_tag --build-arg base=$base --build-arg user_id=$user_id $DIR/$image_name
 echo "Built $image_plus_tag"
 
 # If building the tutorial image
 if [[ "$image_name" == icra2023_tutorial ]]; then
   # DockerHub repo name
   repo_plus_tag_suffix="osrf/icra2023_ros2_gz_tutorial:tutorial$tag_suffix"
-  docker tag $image_plus_tag $repo_plus_tag_suffix
+  ${DOCKER_CMD_PREFIX} docker tag $image_plus_tag $repo_plus_tag_suffix
   echo "Tagged as $repo_plus_tag_suffix"
 fi

--- a/docker/build.bash
+++ b/docker/build.bash
@@ -31,6 +31,14 @@ then
     exit 1
 fi
 
+# If the user is not in the docker group, provide an informative error message
+if [[ $(grep /etc/group -e "docker") != *"${USER}"* ]]; then
+  >&2 echo -e "Error: The current user '${USER}' is not in the docker group. \
+Before trying again, please add your \$USER to the docker group with the \
+following command, and then log out and log back in for changes to take effect:\
+\n\n\tsudo usermod -a -G docker \$USER\n"
+fi
+
 # Get path to current directory
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 

--- a/docker/join.bash
+++ b/docker/join.bash
@@ -22,7 +22,14 @@ IMG=$(basename $1)
 # cannot use `basename`.
 #IMG="$1"
 
+# If the user is not in the docker group, run the docker command with sudo
+if [[ $(grep /etc/group -e "docker") == *"${USER}"* ]]; then
+  DOCKER_CMD_PREFIX=""
+else
+  DOCKER_CMD_PREFIX="sudo"
+fi
+
 xhost +
 containerid=$(docker ps -aqf "ancestor=${IMG}")
-docker exec --privileged -e DISPLAY=${DISPLAY} -e LINES=`tput lines` -it ${containerid} bash
+${DOCKER_CMD_PREFIX} docker exec --privileged -e DISPLAY=${DISPLAY} -e LINES=`tput lines` -it ${containerid} bash
 xhost -

--- a/docker/join.bash
+++ b/docker/join.bash
@@ -22,14 +22,7 @@ IMG=$(basename $1)
 # cannot use `basename`.
 #IMG="$1"
 
-# If the user is not in the docker group, run the docker command with sudo
-if [[ $(grep /etc/group -e "docker") == *"${USER}"* ]]; then
-  DOCKER_CMD_PREFIX=""
-else
-  DOCKER_CMD_PREFIX="sudo"
-fi
-
 xhost +
 containerid=$(docker ps -aqf "ancestor=${IMG}")
-${DOCKER_CMD_PREFIX} docker exec --privileged -e DISPLAY=${DISPLAY} -e LINES=`tput lines` -it ${containerid} bash
+docker exec --privileged -e DISPLAY=${DISPLAY} -e LINES=`tput lines` -it ${containerid} bash
 xhost -

--- a/docker/run.bash
+++ b/docker/run.bash
@@ -112,19 +112,12 @@ done
 # E.g.:
 # -v "/opt/sublime_text:/opt/sublime_text" \
 
-# If the user is not in the docker group, run the docker command with sudo
-if [[ $(grep /etc/group -e "docker") == *"${USER}"* ]]; then
-  DOCKER_CMD_PREFIX=""
-else
-  DOCKER_CMD_PREFIX="sudo"
-fi
-
 # Relax X server permissions so that local X connections work; this is necessary
 # when running under XWayland
 xhost + local:
 
 # --ipc=host and --network=host are needed for no-NVIDIA Dockerfile to work
-${DOCKER_CMD_PREFIX} docker run -it \
+docker run -it \
   -e DISPLAY \
   -e QT_X11_NO_MITSHM=1 \
   -e XAUTHORITY=$XAUTH \

--- a/docker/run.bash
+++ b/docker/run.bash
@@ -31,6 +31,14 @@ then
     exit 1
 fi
 
+# If the user is not in the docker group, provide an informative error message
+if [[ $(grep /etc/group -e "docker") != *"${USER}"* ]]; then
+  >&2 echo -e "Error: The current user '${USER}' is not in the docker group. \
+Before trying again, please add your \$USER to the docker group with the \
+following command, and then log out and log back in for changes to take effect:\
+\n\n\tsudo usermod -a -G docker \$USER\n"
+fi
+
 # Default to NVIDIA
 DOCKER_OPTS="--runtime=nvidia"
 

--- a/docker/run.bash
+++ b/docker/run.bash
@@ -112,12 +112,19 @@ done
 # E.g.:
 # -v "/opt/sublime_text:/opt/sublime_text" \
 
+# If the user is not in the docker group, run the docker command with sudo
+if [[ $(grep /etc/group -e "docker") == *"${USER}"* ]]; then
+  DOCKER_CMD_PREFIX=""
+else
+  DOCKER_CMD_PREFIX="sudo"
+fi
+
 # Relax X server permissions so that local X connections work; this is necessary
 # when running under XWayland
 xhost + local:
 
 # --ipc=host and --network=host are needed for no-NVIDIA Dockerfile to work
-docker run -it \
+${DOCKER_CMD_PREFIX} docker run -it \
   -e DISPLAY \
   -e QT_X11_NO_MITSHM=1 \
   -e XAUTHORITY=$XAUTH \


### PR DESCRIPTION
Related to https://github.com/osrf/icra2023_ros2_gz_tutorial/pull/17#issuecomment-1552268544, this PR makes all `docker ...` calls in scripts run as `sudo docker ...` if the current `${USER}` is not detected in the `docker` group. Hopefully, this can save some time for participants that install Docker on-site by not having to deal with permission errors if the step was skipped during installation, or by needing to relog/reboot after they fix it (or someone helps them).

The detection is based on https://stackoverflow.com/a/39920850

I tested it by removing myself from the `docker` group (`gpasswd -d ${USER} docker`) and running `docker/run.bash`. As expected, the script fails when run with the original script (error: `docker: Got permission denied while trying to connect to the Docker daemon socket ...`). With this PR, I need to enter my password and then the container starts correctly.

What is your opinion about this? Let me know if you prefer some other syntax for it.

---

On an unrelated topic, I should note that the error itself *could* be lost between the output of `xhost`:
```
❯ docker/run.bash icra2023_tutorial
icra2023_tutorial
non-network local connections being added to access control list
docker: Got permission denied while trying to connect to the Docker daemon socket at unix:///var/run/docker.sock: Post "http://%2Fvar%2Frun%2Fdocker.sock/v1.24/containers/create": dial unix /var/run/docker.sock: connect: permission denied.
See 'docker run --help'.
non-network local connections being removed from access control list
```
Maybe it is worth suppressing the output of `xhost +`/`xhost -` to reduce confusion for participants? It is not necessary, just a thought...