### PR TITLE
Burn Gazebo Fuel models into Docker image

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -22,12 +22,15 @@ If you don't have an NVIDIA GPU, Gazebo GUI will use software rendering via
 Mesa llvmpipe (you can check that in `~/.gz/rendering/ogre2.log` after starting
 the Gazebo GUI).
 
-## Pull from DockerHub
+## Pull from DockerHub (recommended)
 
-This image (and possibly some extra data) is built and pushed to DockerHub under
+This is the easiest way to get set up and running.
+
+The image in this directory, along with 3D models used in the tutorial, is
+built and pushed to DockerHub under
 [osrf/icra2023_ros2_gz_tutorial](https://hub.docker.com/r/osrf/icra2023_ros2_gz_tutorial/tags).
 
-You can pull it from DockerHub and skip building it locally:
+You can pull it from DockerHub:
 ```
 docker pull osrf/icra2023_ros2_gz_tutorial:<tag>
 ```
@@ -37,6 +40,10 @@ have an NVIDIA GPU.
 ## Build the image locally
 
 Skip this step if you already pulled the image from DockerHub.
+
+This builds the image from scratch. This gives you a working environment, but
+it does not contain some extra data that we included in the images on DockerHub
+intended to make parts of the tutorial possible without WiFi.
 
 If you have an NVIDIA graphics card, build using the NVIDIA Docker base image:
 ```

--- a/docker/README.md
+++ b/docker/README.md
@@ -101,6 +101,8 @@ For convenience, if you built the image locally, this is an equivalent command
 that you can tab-complete:
 ```
 ./run.bash icra2023_tutorial
+# Or
+./run.bash icra2023_tutorial --no-nvidia
 ```
 
 You can see the list of all images with

--- a/docker/README.md
+++ b/docker/README.md
@@ -52,6 +52,39 @@ Otherwise, build without NVIDIA Docker:
 A few tags will be created for the same image, for convenience of running
 commands.
 
+### For maintainers building image to push to DockerHub
+
+To speed up load time of Gazebo worlds containing large 3D models from Fuel
+(e.g. on tutorial day), you can burn the Fuel data into the image ahead of time.
+
+Follow the section below to run the image, then launch Gazebo with your desired
+worlds (for splash screen worlds, simply run `gz sim` and select the worlds
+from the splash screen).
+
+The models may take a while to download from Fuel, while the Gazebo window
+remains black. Once the world is loaded, close Gazebo.
+
+Repeat for each world desired.
+
+Outside the container, on the host machine, copy the data out from the Docker
+container, to this directory (`./fuel`):
+```
+docker cp trusting_albattani:/home/developer/.gz/fuel fuel
+```
+
+Uncomment these lines in `icra2023_tutorial/Dockerfile`:
+```
+RUN mkdir -p "/home/$USERNAME/.gz/fuel"
+COPY --chown=$USERNAME \
+  ["fuel", \
+  "/home/$USERNAME/.gz/fuel"]
+```
+
+Then rebuild the image as above.
+Now the image will contain all the Fuel models of the Gazebo worlds you loaded.
+Next time you run the image, it will not need to download the Fuel data (unless
+a new version of a model becomes available).
+
 ## Run the image
 
 To spin up a container from an image, this should work whether you pulled from

--- a/docker/README.md
+++ b/docker/README.md
@@ -52,46 +52,6 @@ Otherwise, build without NVIDIA Docker:
 A few tags will be created for the same image, for convenience of running
 commands.
 
-### For maintainers building image to push to DockerHub
-
-To speed up load time of Gazebo worlds containing large 3D models from Fuel
-(e.g. on tutorial day), you can burn the Fuel data into the image ahead of time.
-
-Follow the section below to run the image, then launch Gazebo with your desired
-worlds (for splash screen worlds, simply run `gz sim` and select the worlds
-from the splash screen).
-
-The models may take a while to download from Fuel, while the Gazebo window
-remains black. Once the world is loaded, close Gazebo.
-
-Repeat for each world desired.
-
-Outside the container, on the host machine, copy the data out from the Docker
-container, to this directory (`./fuel`):
-```
-docker cp trusting_albattani:/home/developer/.gz/fuel fuel
-```
-
-Uncomment these lines in `icra2023_tutorial/Dockerfile`:
-```
-RUN mkdir -p "/home/$USERNAME/.gz/fuel"
-COPY --chown=$USERNAME \
-  ["fuel", \
-  "/home/$USERNAME/.gz/fuel"]
-```
-
-Then rebuild the image as above.
-Now the image will contain all the Fuel models of the Gazebo worlds you loaded.
-Next time you run the image, it will not need to download the Fuel data (unless
-a new version of a model becomes available).
-
-To push to DockerHub, make sure you have built both tags, then run
-```
-docker login
-docker push osrf/icra2023_ros2_gz_tutorial:tutorial_nvidia
-docker push osrf/icra2023_ros2_gz_tutorial:tutorial_no_nvidia
-```
-
 ## Run the image
 
 To spin up a container from an image, this should work whether you pulled from
@@ -214,3 +174,49 @@ export GZ_VERSION=garden
 
 For details, see Gazebo documentation on
 [Installing Gazebo with ROS](https://gazebosim.org/docs/garden/ros_installation).
+
+## For maintainers
+
+### For maintainers building image for DockerHub
+
+To speed up load time of Gazebo worlds containing large 3D models from Fuel
+(e.g. on tutorial day), you can burn the Fuel data into the image ahead of time.
+
+Follow the section below to run the image, then launch Gazebo with your desired
+worlds (for splash screen worlds, simply run `gz sim` and select the worlds
+from the splash screen).
+
+The models may take a while to download from Fuel, while the Gazebo window
+remains black. Once the world is loaded, close Gazebo.
+
+Repeat for each world desired.
+
+Outside the container, on the host machine, copy the data out from the Docker
+container, to this directory (`./fuel`):
+```
+docker cp trusting_albattani:/home/developer/.gz/fuel fuel
+```
+
+Uncomment these lines in `icra2023_tutorial/Dockerfile`:
+```
+RUN mkdir -p "/home/$USERNAME/.gz/fuel"
+COPY --chown=$USERNAME \
+  ["fuel", \
+  "/home/$USERNAME/.gz/fuel"]
+```
+
+Then rebuild the image as above.
+Now the image will contain all the Fuel models of the Gazebo worlds you loaded.
+Next time you run the image, it will not need to download the Fuel data (unless
+a new version of a model becomes available).
+
+### For maintainers only: Push to DockerHub
+
+Skip this section if you are not a maintainer of this repository.
+
+To push to DockerHub, make sure you have built both tags, then run
+```
+docker login
+docker push osrf/icra2023_ros2_gz_tutorial:tutorial_nvidia
+docker push osrf/icra2023_ros2_gz_tutorial:tutorial_no_nvidia
+```

--- a/docker/README.md
+++ b/docker/README.md
@@ -220,14 +220,6 @@ container, to this directory (`./fuel`):
 docker cp trusting_albattani:/home/developer/.gz/fuel fuel
 ```
 
-Uncomment these lines in `icra2023_tutorial/Dockerfile`:
-```
-RUN mkdir -p "/home/$USERNAME/.gz/fuel"
-COPY --chown=$USERNAME \
-  ["fuel", \
-  "/home/$USERNAME/.gz/fuel"]
-```
-
 Then rebuild the image as above.
 Now the image will contain all the Fuel models of the Gazebo worlds you loaded.
 Next time you run the image, it will not need to download the Fuel data (unless

--- a/docker/README.md
+++ b/docker/README.md
@@ -85,6 +85,13 @@ Now the image will contain all the Fuel models of the Gazebo worlds you loaded.
 Next time you run the image, it will not need to download the Fuel data (unless
 a new version of a model becomes available).
 
+To push to DockerHub, make sure you have built both tags, then run
+```
+docker login
+docker push osrf/icra2023_ros2_gz_tutorial:tutorial_nvidia
+docker push osrf/icra2023_ros2_gz_tutorial:tutorial_no_nvidia
+```
+
 ## Run the image
 
 To spin up a container from an image, this should work whether you pulled from

--- a/docker/build.bash
+++ b/docker/build.bash
@@ -73,7 +73,7 @@ image_name=$(basename $1)
 image_plus_tag=$image_name:latest
 
 echo "Building $image_name with base image $base"
-docker build --rm -t $image_plus_tag --build-arg base=$base --build-arg user_id=$user_id $DIR/$image_name
+docker build --rm -t $image_plus_tag --build-arg base=$base --build-arg user_id=$user_id -f $DIR/$image_name/Dockerfile .
 echo "Built $image_plus_tag"
 
 # If building the tutorial image

--- a/docker/icra2023_tutorial/Dockerfile
+++ b/docker/icra2023_tutorial/Dockerfile
@@ -145,15 +145,17 @@ RUN cd /home/$USERNAME && git clone https://github.com/ros2/ros2_documentation &
  && cp -av /home/$USERNAME/ros2_documentation/build/html/* /home/$USERNAME/docs.ros.org \
  && rm -rf /home/$USERNAME/ros2_documentation
 
-# Copy Gazebo Fuel data from host.
-# Assumes Dockerfile is being built from a machine that has downloaded
-# Fuel data to a directory ../fuel/ . Otherwise, comment out these lines.
-#RUN mkdir -p "/home/$USERNAME/.gz/fuel"
-#COPY --chown=$USERNAME \
-#  ["fuel", \
-#  "/home/$USERNAME/.gz/fuel"]
-
 RUN mkdir -p /home/$USERNAME/ws_moveit2/src && cd /home/$USERNAME/ws_moveit2/src && git clone https://github.com/ros-planning/moveit2_tutorials -b humble --depth 1 && git clone https://github.com/ros-planning/moveit_task_constructor.git -b humble --depth 1
+
+# Copy Gazebo Fuel data from host if it exists
+# Assumes Dockerfile is being built from a machine that has downloaded
+# Fuel data to a directory ../fuel/ . Otherwise, no fuel data is included.
+RUN mkdir -p "/home/$USERNAME/.gz/fuel"
+# Note the weird spelling of "fuel" as the source; this is to only copy
+# if the "fuel" directory exists (via Docker glob support).  See
+# https://stackoverflow.com/questions/70096208/dockerfile-copy-folder-if-it-exists-conditional-copy/70096420#70096420
+COPY --chown=$USERNAME build.bash fue[l] /home/$USERNAME/.gz/fuel
+RUN rm -f build.bash
 
 # Start a webserver on localhost:9090 for the ROS 2 documentation, and drop to a bash shell
 CMD ["/bin/bash", "-c", "pushd /home/$USERNAME/docs.ros.org && python3 -m http.server 9090 >& /dev/null & /bin/bash"]

--- a/docker/icra2023_tutorial/Dockerfile
+++ b/docker/icra2023_tutorial/Dockerfile
@@ -112,5 +112,13 @@ RUN cd /home/$USERNAME && git clone https://github.com/ros2/ros2_documentation &
  && cp -av /home/$USERNAME/ros2_documentation/build/html/* /home/$USERNAME/docs.ros.org \
  && rm -rf /home/$USERNAME/ros2_documentation
 
+# Copy Gazebo Fuel data from host.
+# Assumes Dockerfile is being built from a machine that has downloaded
+# Fuel data to a directory ../fuel/ . Otherwise, comment out these lines.
+#RUN mkdir -p "/home/$USERNAME/.gz/fuel"
+#COPY --chown=$USERNAME \
+#  ["fuel", \
+#  "/home/$USERNAME/.gz/fuel"]
+
 # Start a webserver on localhost:9090 for the ROS 2 documentation, and drop to a bash shell
 CMD ["/bin/bash", "-c", "pushd /home/$USERNAME/docs.ros.org && python3 -m http.server 9090 >& /dev/null & /bin/bash"]


### PR DESCRIPTION
README contains new instructions to burn Fuel data into image.
I tested locally and pushed new image containing Fuel models for the 5 Gazebo splash screen worlds to DockerHub.