### PR TITLE
Docker save and load commands for file on disk

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -204,11 +204,5 @@ docker save osrf/icra2023_ros2_gz_tutorial:tutorial_nvidia | gzip > tutorial_nvi
 docker save osrf/icra2023_ros2_gz_tutorial:tutorial_no_nvidia | gzip > tutorial_no_nvidia.tar.gz
 ```
 
-Regular tar (larger file size):
-```
-docker save osrf/icra2023_ros2_gz_tutorial:tutorial_nvidia > tutorial_nvidia.tar
-docker save osrf/icra2023_ros2_gz_tutorial:tutorial_no_nvidia > tutorial_no_nvidia.tar
-```
-
 To load the file back into Docker as an image, use `docker load` as described
 in a section above.

--- a/docker/README.md
+++ b/docker/README.md
@@ -22,7 +22,7 @@ If you don't have an NVIDIA GPU, Gazebo GUI will use software rendering via
 Mesa llvmpipe (you can check that in `~/.gz/rendering/ogre2.log` after starting
 the Gazebo GUI).
 
-## Pull from DockerHub
+## Option 1: Pull from DockerHub
 
 This image (and possibly some extra data) is built and pushed to DockerHub under
 [osrf/icra2023_ros2_gz_tutorial](https://hub.docker.com/r/osrf/icra2023_ros2_gz_tutorial/tags).
@@ -34,7 +34,7 @@ docker pull osrf/icra2023_ros2_gz_tutorial:<tag>
 Replace `<tag>` with `tutorial_nvidia` or `tutorial_no_nvidia`, depending on whether you
 have an NVIDIA GPU.
 
-## Build the image locally
+## Option 2: Build the image locally
 
 Skip this step if you already pulled the image from DockerHub.
 
@@ -51,6 +51,22 @@ Otherwise, build without NVIDIA Docker:
 
 A few tags will be created for the same image, for convenience of running
 commands.
+
+## Option 3: Load the image from a file
+
+Skip this step if you already pulled the image from DockerHub, or if you built
+the image locally.
+
+If the two options above fail for you, you may be given a compressed file
+(e.g. on the day of the tutorial, but please try the two options above first).
+
+You can load the file as a Docker image, e.g.
+```
+docker load < file.tar.gz
+```
+
+This should be quick, but of course depends on your machine specifications
+(took 1 minute from internal SSD on Dell XPS 15 9570 from 2018).
 
 ## Run the image
 
@@ -172,3 +188,27 @@ export GZ_VERSION=garden
 
 For details, see Gazebo documentation on
 [Installing Gazebo with ROS](https://gazebosim.org/docs/garden/ros_installation).
+
+## For maintainers
+
+### For maintainers only: Save Docker image to disk
+
+You may want to save the compiled Docker image to disk, e.g. on a USB drive.
+
+This will take a few minutes (gzip option to internal SSD took 5 minutes on
+Dell XPS 15 9570 from 2018).
+
+You can use gzip (file size much smaller than tar):
+```
+docker save osrf/icra2023_ros2_gz_tutorial:tutorial_nvidia | gzip > tutorial_nvidia.tar.gz
+docker save osrf/icra2023_ros2_gz_tutorial:tutorial_no_nvidia | gzip > tutorial_no_nvidia.tar.gz
+```
+
+Regular tar (larger file size):
+```
+docker save osrf/icra2023_ros2_gz_tutorial:tutorial_nvidia > tutorial_nvidia.tar
+docker save osrf/icra2023_ros2_gz_tutorial:tutorial_no_nvidia > tutorial_no_nvidia.tar
+```
+
+To load the file back into Docker as an image, use `docker load` as described
+in a section above.


### PR DESCRIPTION
Tested `docker save` and `docker load`, for writing/reading Docker image to/from disk.

I didn't test on USB stick, only on internal SSD on my host machine.
Took 5 minutes to output to gzip on disk (only maintainers need to do this), 1 minute to load gzip back to Docker (users need to do this).

For reference, the read speed of SanDisk 32GB Ultra USB 3.0 Flash Drive USB is 100 MB/s.
My SSD's write speed is 727 MB/s, read speed is 8.3 GB/s :sweat_smile: 
```
$ sudo /sbin/sysctl -w vm.drop_caches=3
$ sync; dd if=/dev/zero of=tempfile bs=1M count=1024; sync
1024+0 records in
1024+0 records out
1073741824 bytes (1.1 GB, 1.0 GiB) copied, 1.47615 s, 727 MB/s
$ dd if=tempfile of=/dev/null bs=1M count=1024
1024+0 records in
1024+0 records out
1073741824 bytes (1.1 GB, 1.0 GiB) copied, 0.129964 s, 8.3 GB/s
```
Commands from [here](https://www.makeuseof.com/ways-test-ssd-speed-performance/)

Soooooooooo we should test on those USBs to get a better estimate.