### PR TITLE
Fix the join command to use the correct syntax.

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -110,7 +110,12 @@ alias run_osrf_icra="/absolute/path/to/run.bash osrf/icra2023_ros2_gz_tutorial:t
 
 To join a running container from another terminal:
 ```
-./join.bash icra2023_tutorial
+./join.bash osrf/icra2023_ros2_gz_tutorial:tutorial_nvidia
+```
+
+or:
+```
+./join.bash osrf/icra2023_ros2_gz_tutorial:tutorial_no_nvidia
 ```
 
 ## Test the image

--- a/docker/README.md
+++ b/docker/README.md
@@ -111,11 +111,16 @@ alias run_osrf_icra="/absolute/path/to/run.bash osrf/icra2023_ros2_gz_tutorial:t
 To join a running container from another terminal:
 ```
 ./join.bash osrf/icra2023_ros2_gz_tutorial:tutorial_nvidia
+# Or
+./join.bash osrf/icra2023_ros2_gz_tutorial:tutorial_no_nvidia
 ```
 
-or:
+For convenience, if you built the image locally, this is an equivalent command
+that you can tab-complete:
 ```
-./join.bash osrf/icra2023_ros2_gz_tutorial:tutorial_no_nvidia
+./join.bash icra2023_tutorial
+# Or
+./join.bash icra2023_tutorial --no-nvidia
 ```
 
 ## Test the image


### PR DESCRIPTION
This makes it match the `run.bash` command, and is what I needed to use in order to make it work with the image fetched from dockerhub.