### PR TITLE
Fix join script for DockerHub image containing slash

### DIFF
--- a/docker/join.bash
+++ b/docker/join.bash
@@ -17,10 +17,16 @@
 #
 #
 
-IMG=$(basename $1)
+#IMG=$(basename $1)
 # Use quotes if image name contains symbols like a forward slash /, but then
 # cannot use `basename`.
-#IMG="$1"
+IMG="$1"
+
+# Truncate last "/" in case using bash-complete for directory name
+if [[ $IMG == */ ]]; then
+  IMG=${IMG::-1}
+fi
+echo $IMG
 
 xhost +
 containerid=$(docker ps -aqf "ancestor=${IMG}")


### PR DESCRIPTION
Documentation was changed in #32 but the script wasn't updated to work with the new README