### PR TITLE
Add Turtlebot 4 sim to Dockerfile

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -238,8 +238,13 @@ remains black. Once the world is loaded, close Gazebo.
 
 Repeat for each world desired.
 
-Outside the container, on the host machine, copy the data out from the Docker
-container, to this directory (`./fuel`):
+Outside the container, on the host machine, find the name of your container:
+```
+docker container ls
+```
+Say we find our container name to be `trusting_albattani`.
+
+Copy the data out from the Docker container to this directory (`./fuel`):
 ```
 docker cp trusting_albattani:/home/developer/.gz/fuel fuel
 ```

--- a/docker/icra2023_tutorial/Dockerfile
+++ b/docker/icra2023_tutorial/Dockerfile
@@ -173,5 +173,11 @@ RUN mkdir -p "/home/$USERNAME/.gz/fuel"
 COPY --chown=$USERNAME build.bash fue[l] /home/$USERNAME/.gz/fuel
 RUN rm -f build.bash
 
+# Optional: Similarly, copy Turtlebot 4 Gazebo Fuel data from host (this is in
+# ~/.ignition as opposed to ~/.gz because Turtlebot 4 runs in Gazebo Fortress).
+RUN mkdir -p "/home/$USERNAME/.ignition/fuel"
+COPY --chown=$USERNAME build.bash fuel_fortres[s] /home/$USERNAME/.ignition/fuel
+RUN rm -f build.bash
+
 # Start a webserver on localhost:9090 for the ROS 2 documentation, and drop to a bash shell
 CMD ["/bin/bash", "-c", "pushd /home/$USERNAME/docs.ros.org && python3 -m http.server 9090 >& /dev/null & /bin/bash"]

--- a/docker/icra2023_tutorial/Dockerfile
+++ b/docker/icra2023_tutorial/Dockerfile
@@ -136,18 +136,35 @@ WORKDIR /home/$USERNAME
 RUN sudo rosdep init && rosdep update
 
 # Add colcon mixins
-RUN colcon mixin add default https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml && colcon mixin update default && rm -rf log
+RUN colcon mixin add default https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml \
+ && colcon mixin update default \
+ && rm -rf log
 
-# Build and install the ROS 2 documentation
-RUN cd /home/$USERNAME && git clone https://github.com/ros2/ros2_documentation && cd ros2_documentation \
- && pip3 install -r requirements.txt && PATH=$PATH:/home/$USERNAME/.local/bin make multiversion \
- && mkdir /home/$USERNAME/docs.ros.org \
- && cp -av /home/$USERNAME/ros2_documentation/build/html/* /home/$USERNAME/docs.ros.org \
- && rm -rf /home/$USERNAME/ros2_documentation
+# Optional: Build and install the ROS 2 documentation
+# FIXME new Sphinx version error. Temporarily comment out
+#RUN cd /home/$USERNAME && git clone https://github.com/ros2/ros2_documentation && cd ros2_documentation \
+# && pip3 install -r requirements.txt && PATH=$PATH:/home/$USERNAME/.local/bin make multiversion \
+# && mkdir /home/$USERNAME/docs.ros.org \
+# && cp -av /home/$USERNAME/ros2_documentation/build/html/* /home/$USERNAME/docs.ros.org \
+# && rm -rf /home/$USERNAME/ros2_documentation
 
-RUN mkdir -p /home/$USERNAME/ws_moveit2/src && cd /home/$USERNAME/ws_moveit2/src && git clone https://github.com/ros-planning/moveit2_tutorials -b humble --depth 1 && git clone https://github.com/ros-planning/moveit_task_constructor.git -b humble --depth 1
+RUN mkdir -p /home/$USERNAME/ws_moveit2/src \
+ && cd /home/$USERNAME/ws_moveit2/src \
+ && git clone https://github.com/ros-planning/moveit2_tutorials -b humble --depth 1 \
+ && git clone https://github.com/ros-planning/moveit_task_constructor.git -b humble --depth 1
 
-# Copy Gazebo Fuel data from host if it exists
+# Optional: Turtlebot 4
+# NOTE rosdep install here pulls in Gazebo Fortress, on top of Gazebo Garden
+# being installed in this Dockerfile.
+RUN mkdir -p /home/$USERNAME/turtlebot4_ws/src \
+ && cd /home/$USERNAME/turtlebot4_ws/src \
+ && git clone https://github.com/turtlebot/turtlebot4_simulator.git -b humble \
+ && cd /home/$USERNAME/turtlebot4_ws \
+ && rosdep install --from-path /home/$USERNAME/turtlebot4_ws/src --ignore-src --rosdistro humble -y \
+ && /bin/bash -c 'source /opt/ros/humble/setup.bash && colcon build --symlink-install'
+
+# Optional: Copy Gazebo Fuel data from host if it exists, to speed up world
+# loading time.
 # Assumes Dockerfile is being built from a machine that has downloaded
 # Fuel data to a directory ../fuel/ . Otherwise, no fuel data is included.
 RUN mkdir -p "/home/$USERNAME/.gz/fuel"
@@ -158,4 +175,5 @@ COPY --chown=$USERNAME build.bash fue[l] /home/$USERNAME/.gz/fuel
 RUN rm -f build.bash
 
 # Start a webserver on localhost:9090 for the ROS 2 documentation, and drop to a bash shell
-CMD ["/bin/bash", "-c", "pushd /home/$USERNAME/docs.ros.org && python3 -m http.server 9090 >& /dev/null & /bin/bash"]
+# FIXME uncomment when ros2_documentation build above is fixed
+#CMD ["/bin/bash", "-c", "pushd /home/$USERNAME/docs.ros.org && python3 -m http.server 9090 >& /dev/null & /bin/bash"]


### PR DESCRIPTION
# Tutorial addition

Merge by Tue Feb 16 please.

Add Turtlebot 4 simulation packages to Dockerfile, to use as example for a new run of the tutorial.
Caveat is that
1. `rosdep install` pulls in Gazebo Fortress, which is on top of the Gazebo Garden we are installing in the Dockerfile. This isn't so clean, but I'm not going to change Turtlebot4 since we aren't authors there.
2. It's running at <= 10% RTF on our laptops.
3. Bringup takes a while. We thought it's just downloading models, but I checked ~/.gz/fuel afterwards, and there are no new models added beyond the splash screen ones? The world seems similar to one of the Gazebo splash screen ones we already burned into the Docker image.

Also
Commented out ros2_documentation build because new Sphinx version error in #42.

## Test

Follow test instructions here to build Dockerfile and test `rviz2` and `gz sim`:
https://github.com/osrf/icra2023_ros2_gz_tutorial/tree/main/docker

Plus test TB4
```
. ~/turtlebot4_ws/install/setup.bash
ros2 launch turtlebot4_ignition_bringup turtlebot4_ignition.launch.py
```